### PR TITLE
semanticClass and HTML/XML changes

### DIFF
--- a/Themes/Brilliance Black.tmTheme
+++ b/Themes/Brilliance Black.tmTheme
@@ -8,6 +8,8 @@
 	<string>Thomas Aylott ㊷ subtleGradient.com</string>
 	<key>name</key>
 	<string>Brilliance Black</string>
+	<key>semanticClass</key>
+	<string>theme.dark.brilliance-black</string>
 	<key>settings</key>
 	<array>
 		<dict>

--- a/Themes/Brilliance Black.tmTheme
+++ b/Themes/Brilliance Black.tmTheme
@@ -815,7 +815,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Doctype</string>
 			<key>scope</key>
-			<string>meta.doctype, meta.tag.sgml-declaration.doctype, meta.tag.sgml.doctype</string>
+			<string>meta.tag.metadata.doctype</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -889,7 +889,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Other</string>
 			<key>scope</key>
-			<string>meta.tag.other, entity.name.tag.style, entity.name.tag.script, meta.tag.block.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
+			<string>meta.tag.other, meta.tag.metadata.style entity.name.tag, meta.tag.metadata.script entity.name.tag, meta.tag.metadata.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -902,7 +902,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Form</string>
 			<key>scope</key>
-			<string>meta.tag.form, meta.tag.block.form, meta.tag.inline.form</string>
+			<string>meta.tag.structure.form, meta.tag.block.form, meta.tag.inline.form</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -915,7 +915,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Void</string>
 			<key>scope</key>
-			<string>meta.tag.inline.any.void, meta.tag.form.any.void</string>
+			<string>meta.tag.*.*.void, meta.tag.*.*.*.void</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>

--- a/Themes/Brilliance Dull.tmTheme
+++ b/Themes/Brilliance Dull.tmTheme
@@ -828,7 +828,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Doctype</string>
 			<key>scope</key>
-			<string>meta.doctype, meta.tag.sgml-declaration.doctype, meta.tag.sgml.doctype</string>
+			<string>meta.tag.metadata.doctype</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -902,7 +902,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Other</string>
 			<key>scope</key>
-			<string>meta.tag.other, entity.name.tag.style, entity.name.tag.script, meta.tag.block.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
+			<string>meta.tag.other, meta.tag.metadata.style entity.name.tag, meta.tag.metadata.script entity.name.tag, meta.tag.metadata.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -915,7 +915,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Form</string>
 			<key>scope</key>
-			<string>meta.tag.form, meta.tag.block.form, meta.tag.inline.form</string>
+			<string>meta.tag.structure.form, meta.tag.block.form, meta.tag.inline.form</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -928,7 +928,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Void</string>
 			<key>scope</key>
-			<string>meta.tag.inline.any.void, meta.tag.form.any.void</string>
+			<string>meta.tag.*.*.void, meta.tag.*.*.*.void</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>

--- a/Themes/Brilliance Dull.tmTheme
+++ b/Themes/Brilliance Dull.tmTheme
@@ -8,6 +8,8 @@
 	<string>Thomas Aylott ㊷ subtleGradient.com</string>
 	<key>name</key>
 	<string>Brilliance Dull</string>
+	<key>semanticClass</key>
+	<string>theme.dark.brilliance-dull</string>
 	<key>settings</key>
 	<array>
 		<dict>

--- a/Themes/Brilliance White.tmTheme
+++ b/Themes/Brilliance White.tmTheme
@@ -8,6 +8,8 @@
 	<string>Thomas Aylott ㊷ subtleGradient.com</string>
 	<key>name</key>
 	<string>Brilliance White</string>
+	<key>semanticClass</key>
+	<string>theme.light.brilliance-white</string>
 	<key>settings</key>
 	<array>
 		<dict>

--- a/Themes/Brilliance White.tmTheme
+++ b/Themes/Brilliance White.tmTheme
@@ -823,7 +823,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Doctype</string>
 			<key>scope</key>
-			<string>meta.doctype, meta.tag.sgml-declaration.doctype, meta.tag.sgml.doctype</string>
+			<string>meta.tag.metadata.doctype</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -1049,7 +1049,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Other</string>
 			<key>scope</key>
-			<string>meta.tag.other, entity.name.tag.style, entity.name.tag.script, meta.tag.block.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
+			<string>meta.tag.other, meta.tag.metadata.style entity.name.tag, meta.tag.metadata.script entity.name.tag, meta.tag.metadata.script, source.js.embedded punctuation.definition.tag.html, source.css.embedded punctuation.definition.tag.html</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -1075,7 +1075,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Form</string>
 			<key>scope</key>
-			<string>meta.tag.form, meta.tag.block.form, meta.tag.inline.form</string>
+			<string>meta.tag.structure.form, meta.tag.block.form, meta.tag.inline.form</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>
@@ -1114,7 +1114,7 @@ meta.brace.round</string>
 			<key>name</key>
 			<string>✘ Tag Input</string>
 			<key>scope</key>
-			<string>meta.tag.inline.any.void, meta.tag.form.any.void</string>
+			<string>meta.tag.*.*.void, meta.tag.*.*.*.void</string>
 			<key>settings</key>
 			<dict>
 				<key>background</key>


### PR DESCRIPTION
Couple quick changes:

- Adds semanticClass which organizes the themes into dark/light groupings in the theme menu.
- The HTML grammar is getting updated with some grouping changes which necessitated some changes to keep themes working, the XML grammar is also being updated to match.

Notes:

- XML grammar is live, HTML grammar will be in 24-48 hours. Nothing is being deployed to the updater until I do so as a batch at one time once a final testing pass of everything.
- There were some parts of the theme with scopes I don't recognize like `meta.section.html.head`, these don't work but I don't think they ever did with the standard grammar? I'm working to make meta.element contain the tag and it's contents but that won't make it in this pass.